### PR TITLE
HOTFIX: Fix broken documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Polar Next.js Example App
 
-This repository demonstrates how you can setup Polar with Next.js with ease. [Read the Polar Next.js integration guide for more information.](https://polar.sh/docs/guides/nextjs)
+This repository demonstrates how you can setup Polar with Next.js with ease. [Read the Polar Next.js integration guide for more information.](https://docs.polar.sh/documentation/integration-guides/nextjs)
 
 This repository covers the following concepts:
 


### PR DESCRIPTION
Hey everyone 👋

I was checking out the repo and noticed the docs link in the README was leading to a 404. I updated it to a working URL so the next person won’t run into the same confusion.

I'm considering giving polar a testrun for my SaaS, docs seem promising so I hope to stick around.

Cheers,
- Maz